### PR TITLE
🔨 Update scripts

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,8 +1,10 @@
 #! /usr/bin/env bash
 
-set -e
+set -euC
+set -o pipefail
 set -x
 
-FILES_TO_FORMAT="src tests scripts"
-black $FILES_TO_FORMAT
-isort $FILES_TO_FORMAT
+FILES_TO_FORMAT=("src" "tests" "scripts")
+
+black "${FILES_TO_FORMAT[@]}"
+isort "${FILES_TO_FORMAT[@]}"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,11 +1,12 @@
 #! /usr/bin/env bash
 
-set -e
+set -euC
+set -o pipefail
 set -x
 
-FILES_TO_CHECK="src tests"
+FILES_TO_FORMAT=("src" "tests")
 
-flake8 $FILES_TO_CHECK
-black $FILES_TO_CHECK --check
-isort $FILES_TO_CHECK --check-only
-mypy $FILES_TO_CHECK
+flake8 "${FILES_TO_FORMAT[@]}"
+black --check "${FILES_TO_FORMAT[@]}"
+isort --check-only "${FILES_TO_FORMAT[@]}"
+mypy "${FILES_TO_FORMAT[@]}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
-set -e
+set -euC
+set -o pipefail
 set -x
 
 VERSION=$(hatch version)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
-set -e
+set -euC
+set -o pipefail
 set -x
 
 # pytest --doctest-modules src  # Uncomment when to run doctests


### PR DESCRIPTION
## Description

Fixed potential bugs in shell scripts by adding the following options.

- `-u`: Treat unset variables and parameters as an error
- `-C`: Prevent output redirection using ‘>’, ‘>&’, and ‘<>’ from overwriting existing files.
- `-o pipefail`: the return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully.

## References

- https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html