### PR TITLE
🐛 Fix credentials validator raises TypeError

### DIFF
--- a/src/gcrostore/models.py
+++ b/src/gcrostore/models.py
@@ -37,10 +37,8 @@ class Google(pydantic.BaseModel):
     sheet_id: str
 
     @pydantic.validator("creds")
-    def creds_is_valid(cls, v: t.Any) -> dict[str, t.Any]:
+    def creds_is_valid(cls, v: t.Any) -> t.Any:
         creds = credentials.Credentials.from_authorized_user_info(v, config.scopes)
         if not creds.valid and creds.refresh_token:
             creds.refresh(requests.Request())
-        refreshed_creds = json.loads(creds.to_json())
-        assert isinstance(refreshed_creds, dict)
-        return {str(key): val for (key, val) in refreshed_creds.items()}
+        return json.loads(creds.to_json())

--- a/src/gcrostore/models.py
+++ b/src/gcrostore/models.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import typing as t
 from collections import abc
 
@@ -40,4 +41,6 @@ class Google(pydantic.BaseModel):
         creds = credentials.Credentials.from_authorized_user_info(v, config.scopes)
         if not creds.valid and creds.refresh_token:
             creds.refresh(requests.Request())
-        return dict(creds)
+        refreshed_creds = json.loads(creds.to_json())
+        assert isinstance(refreshed_creds, dict)
+        return {str(key): val for (key, val) in refreshed_creds.items()}


### PR DESCRIPTION
## Description

The endpoint `/cancel/all` returns the following error for valid credentials.

```json
{"detail":[{"loc":["body","google","creds"],"msg":"'Credentials' object is not iterable","type":"type_error"}]}
```

## Reproducible Code
Not yet.

## Solution

Fix the following line.

https://github.com/huisint/gcrostore/blob/951767bdcd49043606e8544137acfe4dbcf2fbd5/src/gcrostore/models.py#L43

## Version

v0.0.3