### PR TITLE
🐋  No need of any process manager in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.10-bullseye as builder
 RUN pip install -U pip
 WORKDIR /work
 COPY . /work
-RUN pip install .[pro]
+RUN pip install .[prod]
 
 FROM python:3.10-slim-bullseye as runner
 RUN useradd crostore
-COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/bin/uvicorn /usr/local/bin/
 COPY --from=builder /usr/local/lib/python3.10/site-packages /usr/local/lib/python3.10/site-packages
-EXPOSE 8080
-CMD [ "gunicorn", "gcrostore:app", "-b", "0.0.0.0:8080", "--worker-class", "uvicorn.workers.UvicornWorker"]
+EXPOSE 80
+CMD ["uvicorn", "gcrostore:app", "--host", "0.0.0.0", "--port", "80"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,8 @@ dev = [
   "google-auth-oauthlib",
 ]
 doc = []
-pro = [
+prod = [
   "uvicorn[standard]~=0.18.3",
-  "gunicorn~=20.1.0",
   "bugsnag~=4.2.1",
 ]
 


### PR DESCRIPTION
## Description

The process manager like [gunicorn] is not needed any more because it is going to deploy to a container cluster.

## Reference 

https://fastapi.tiangolo.com/deployment/docker/#replication-number-of-processes

[gunicorn]: https://gunicorn.org/