### PR TITLE
🐛 Cannot start selenium session

### DIFF
--- a/src/gcrostore/models.py
+++ b/src/gcrostore/models.py
@@ -1,7 +1,5 @@
-import contextlib
 import json
 import typing as t
-from collections import abc
 
 import pydantic
 from crostore import config as crostore_config
@@ -31,17 +29,13 @@ class Selenium(pydantic.BaseModel):
     def options(self) -> options.ArgOptions:
         return self._options
 
-    @contextlib.contextmanager
-    def driver(self) -> abc.Iterator[webdriver.Remote]:
+    def driver(self) -> webdriver.Remote:
         driver = webdriver.Remote(
-            command_executor=self.url,
+            command_executor=str(self.url),
             options=self.options,
         )
         driver.implicitly_wait(crostore_config.SELENIUM_WAIT)
-        try:
-            yield driver
-        finally:
-            driver.quit()
+        return driver
 
 
 class Google(pydantic.BaseModel):


### PR DESCRIPTION
`models.Selenium.driver()` raises `AttributeError: 'pydantic_core._pydantic_core.Url' object has no attribute 'execute'`

## Reproducible code

```python
import os

from gcrostore import models

selenium = models.Selenium(
    url=os.environ["SELENIUM_URL"],
    desired_capabilities={
        "browserName": "chrome",
        "pageLoadStrategy": "normal",
        "goog:chromeOptions": {},
    },
)

with selenium.driver() as driver:
    driver.get("https://google.com")
```

## Version

v0.0.10
